### PR TITLE
enity_type_id is hard-coded

### DIFF
--- a/app/code/community/Pimgento/Attribute/Model/Import.php
+++ b/app/code/community/Pimgento/Attribute/Model/Import.php
@@ -81,7 +81,7 @@ class Pimgento_Attribute_Model_Import extends Pimgento_Core_Model_Import_Abstrac
                     'entity_id'  => 'attribute_id',
                 )
             )
-            ->where('entity_type_id = ?', 4);
+            ->where('entity_type_id = ?', $this->_entity_type_id('catalog_product'));
 
         $insert = $adapter->insertFromSelect(
             $select,
@@ -414,7 +414,7 @@ class Pimgento_Attribute_Model_Import extends Pimgento_Core_Model_Import_Abstrac
 
         $values = array(
             'attribute_id'   => $data['entity_id'],
-            'entity_type_id' => 4
+            'entity_type_id' => $this->_entity_type_id('catalog_product')
         );
 
         $adapter->insertIgnore($resource->getTable('eav/attribute'), $values);
@@ -506,7 +506,7 @@ class Pimgento_Attribute_Model_Import extends Pimgento_Core_Model_Import_Abstrac
                     'attribute_id',
                 )
             )
-            ->where('entity_type_id = ?', 4);
+            ->where('entity_type_id = ?', $this->_entity_type_id('catalog_product'));
 
         return $adapter->fetchCol($select);
     }

--- a/app/code/community/Pimgento/Attribute/Model/Import.php
+++ b/app/code/community/Pimgento/Attribute/Model/Import.php
@@ -81,7 +81,7 @@ class Pimgento_Attribute_Model_Import extends Pimgento_Core_Model_Import_Abstrac
                     'entity_id'  => 'attribute_id',
                 )
             )
-            ->where('entity_type_id = ?', $this->_entity_type_id('catalog_product'));
+            ->where('entity_type_id = ?', $this->_getEntityTypeId('catalog_product'));
 
         $insert = $adapter->insertFromSelect(
             $select,
@@ -414,7 +414,7 @@ class Pimgento_Attribute_Model_Import extends Pimgento_Core_Model_Import_Abstrac
 
         $values = array(
             'attribute_id'   => $data['entity_id'],
-            'entity_type_id' => $this->_entity_type_id('catalog_product')
+            'entity_type_id' => $this->_getEntityTypeId('catalog_product')
         );
 
         $adapter->insertIgnore($resource->getTable('eav/attribute'), $values);
@@ -506,7 +506,7 @@ class Pimgento_Attribute_Model_Import extends Pimgento_Core_Model_Import_Abstrac
                     'attribute_id',
                 )
             )
-            ->where('entity_type_id = ?', $this->_entity_type_id('catalog_product'));
+            ->where('entity_type_id = ?', $this->_getEntityTypeId('catalog_product'));
 
         return $adapter->fetchCol($select);
     }

--- a/app/code/community/Pimgento/Category/Model/Import.php
+++ b/app/code/community/Pimgento/Category/Model/Import.php
@@ -222,7 +222,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
         );
 
         // Do not update
-        $this->getRequest()->setValues($this->getCode(), 'catalog/category', $values, 3, 0, 2);
+        $this->getRequest()->setValues($this->getCode(), 'catalog/category', $values, $this->_entity_type_id('catalog_category'), 0, 2);
 
         /* @var $helper Pimgento_Core_Helper_Data */
         $helper = Mage::helper('pimgento_core');
@@ -239,7 +239,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
                         'name' => 'label-' . $local,
                     );
 
-                    $this->getRequest()->setValues($this->getCode(), 'catalog/category', $values, 3, $storeId);
+                    $this->getRequest()->setValues($this->getCode(), 'catalog/category', $values, $this->_entity_type_id('catalog_category'), $storeId);
                 }
 
             }
@@ -284,7 +284,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
         $resource = $this->getResource();
         $adapter  = $this->getAdapter();
 
-        $attribute = $resource->getAttribute('url_key', 3);
+        $attribute = $resource->getAttribute('url_key', $this->_entity_type_id('catalog_category'));
 
         /* @var $url Mage_Catalog_Model_Product_Url */
         $url = Mage::getModel('catalog/product_url');

--- a/app/code/community/Pimgento/Category/Model/Import.php
+++ b/app/code/community/Pimgento/Category/Model/Import.php
@@ -184,7 +184,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
                 $this->getTable(),
                 array(
                     'entity_id'        => 'entity_id',
-                    'entity_type_id'   => $this->_zde($this->_entity_type_id('catalog_category')),
+                    'entity_type_id'   => $this->_zde($this->_getEntityTypeId('catalog_category')),
                     'attribute_set_id' => $this->_zde(3),
                     'parent_id'        => 'parent_id',
                     'created_at'       => $this->_zde('now()'),
@@ -222,7 +222,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
         );
 
         // Do not update
-        $this->getRequest()->setValues($this->getCode(), 'catalog/category', $values, $this->_entity_type_id('catalog_category'), 0, 2);
+        $this->getRequest()->setValues($this->getCode(), 'catalog/category', $values, $this->_getEntityTypeId('catalog_category'), 0, 2);
 
         /* @var $helper Pimgento_Core_Helper_Data */
         $helper = Mage::helper('pimgento_core');
@@ -239,7 +239,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
                         'name' => 'label-' . $local,
                     );
 
-                    $this->getRequest()->setValues($this->getCode(), 'catalog/category', $values, $this->_entity_type_id('catalog_category'), $storeId);
+                    $this->getRequest()->setValues($this->getCode(), 'catalog/category', $values, $this->_getEntityTypeId('catalog_category'), $storeId);
                 }
 
             }
@@ -284,7 +284,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
         $resource = $this->getResource();
         $adapter  = $this->getAdapter();
 
-        $attribute = $resource->getAttribute('url_key', $this->_entity_type_id('catalog_category'));
+        $attribute = $resource->getAttribute('url_key', $this->_getEntityTypeId('catalog_category'));
 
         /* @var $url Mage_Catalog_Model_Product_Url */
         $url = Mage::getModel('catalog/product_url');
@@ -310,7 +310,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
                         $new = $url->formatUrlKey($row['name']);
 
                         $values = array(
-                            'entity_type_id' => $this->_zde($this->_entity_type_id('catalog_category')),
+                            'entity_type_id' => $this->_zde($this->_getEntityTypeId('catalog_category')),
                             'attribute_id'   => $this->_zde($attribute['attribute_id']),
                             'store_id'       => $this->_zde($storeId),
                             'entity_id'      => $row['entity_id'],

--- a/app/code/community/Pimgento/Category/Model/Import.php
+++ b/app/code/community/Pimgento/Category/Model/Import.php
@@ -184,7 +184,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
                 $this->getTable(),
                 array(
                     'entity_id'        => 'entity_id',
-                    'entity_type_id'   => $this->_zde(3),
+                    'entity_type_id'   => $this->_zde($this->_entity_type_id('catalog_category')),
                     'attribute_set_id' => $this->_zde(3),
                     'parent_id'        => 'parent_id',
                     'created_at'       => $this->_zde('now()'),
@@ -310,7 +310,7 @@ class Pimgento_Category_Model_Import extends Pimgento_Core_Model_Import_Abstract
                         $new = $url->formatUrlKey($row['name']);
 
                         $values = array(
-                            'entity_type_id' => $this->_zde(3),
+                            'entity_type_id' => $this->_zde($this->_entity_type_id('catalog_category')),
                             'attribute_id'   => $this->_zde($attribute['attribute_id']),
                             'store_id'       => $this->_zde($storeId),
                             'entity_id'      => $row['entity_id'],

--- a/app/code/community/Pimgento/Core/Model/Import/Abstract.php
+++ b/app/code/community/Pimgento/Core/Model/Import/Abstract.php
@@ -204,7 +204,7 @@ abstract class Pimgento_Core_Model_Import_Abstract
              $this->_entity_type_ids = array();
              $entity_types = Mage::getModel('eav/entity_type')->getCollection();
              foreach ($entity_types as $type) {
-                 $this->_entity_type_ids[$type->getEntityCode()] = $type->getId();
+                 $this->_entity_type_ids[$type->getEntityTypeCode()] = $type->getId();
              }
 
         }

--- a/app/code/community/Pimgento/Core/Model/Import/Abstract.php
+++ b/app/code/community/Pimgento/Core/Model/Import/Abstract.php
@@ -14,6 +14,11 @@ abstract class Pimgento_Core_Model_Import_Abstract
     protected $_code;
 
     /**
+     * @var array
+     */
+    protected $_entity_type_ids;
+
+    /**
      * Constructor
      */
     public function _construct()
@@ -184,6 +189,26 @@ abstract class Pimgento_Core_Model_Import_Abstract
     protected function _zde($value)
     {
         return new Zend_Db_Expr($value);
+    }
+
+    /**
+     * Get entity_type_id for a specified entity_type_code
+     *
+     * @param $type_code
+     *
+     * @return string
+     */
+    protected function _entity_type_id($type_code)
+    {
+        if (!isset($this->_entity_type_ids)) {
+             $this->_entity_type_ids = array();
+             $entity_types = Mage::getModel('eav/entity_type')->getCollection();
+             foreach ($entity_types as $type) {
+                 $this->_entity_type_ids[$type->getEntityCode()] = $type->getId();
+             }
+
+        }
+        return $this->_entity_type_ids[$type_code];
     }
 
 }

--- a/app/code/community/Pimgento/Core/Model/Import/Abstract.php
+++ b/app/code/community/Pimgento/Core/Model/Import/Abstract.php
@@ -198,7 +198,7 @@ abstract class Pimgento_Core_Model_Import_Abstract
      *
      * @return string
      */
-    protected function _entity_type_id($type_code)
+    protected function _getEntityTypeId($type_code)
     {
         if (!isset($this->_entity_type_ids)) {
              $this->_entity_type_ids = array();

--- a/app/code/community/Pimgento/Family/Model/Import.php
+++ b/app/code/community/Pimgento/Family/Model/Import.php
@@ -91,7 +91,7 @@ class Pimgento_Family_Model_Import extends Pimgento_Core_Model_Import_Abstract
                 $this->getTable(),
                 array(
                     'attribute_set_id'   => 'entity_id',
-                    'entity_type_id'     => $this->_zde(4),
+                    'entity_type_id'     => $this->_zde($this->_entity_type_id('catalog_product')),
                     'attribute_set_name' => 'label',
                     'sort_order'         => $this->_zde(1),
                 )

--- a/app/code/community/Pimgento/Family/Model/Import.php
+++ b/app/code/community/Pimgento/Family/Model/Import.php
@@ -91,7 +91,7 @@ class Pimgento_Family_Model_Import extends Pimgento_Core_Model_Import_Abstract
                 $this->getTable(),
                 array(
                     'attribute_set_id'   => 'entity_id',
-                    'entity_type_id'     => $this->_zde($this->_entity_type_id('catalog_product')),
+                    'entity_type_id'     => $this->_zde($this->_getEntityTypeId('catalog_product')),
                     'attribute_set_name' => 'label',
                     'sort_order'         => $this->_zde(1),
                 )

--- a/app/code/community/Pimgento/Image/Model/Import.php
+++ b/app/code/community/Pimgento/Image/Model/Import.php
@@ -205,9 +205,9 @@ class Pimgento_Image_Model_Import extends Pimgento_Core_Model_Import_Abstract
             'thumbnail'   => 'thumbnail',
         );
 
-        $this->getRequest()->setValues($this->getCode(), 'catalog/product', $values, 4, 0);
+        $this->getRequest()->setValues($this->getCode(), 'catalog/product', $values, $this->_entity_type_id('catalog_product'), 0);
 
-        $attribute = $resource->getAttribute('media_gallery', 4);
+        $attribute = $resource->getAttribute('media_gallery', $this->_entity_type_id('catalog_product'));
 
         if (!$attribute) {
             $task->setMessage($helper->__('Attribute %s not found', 'media_gallery'));

--- a/app/code/community/Pimgento/Image/Model/Import.php
+++ b/app/code/community/Pimgento/Image/Model/Import.php
@@ -205,9 +205,9 @@ class Pimgento_Image_Model_Import extends Pimgento_Core_Model_Import_Abstract
             'thumbnail'   => 'thumbnail',
         );
 
-        $this->getRequest()->setValues($this->getCode(), 'catalog/product', $values, $this->_entity_type_id('catalog_product'), 0);
+        $this->getRequest()->setValues($this->getCode(), 'catalog/product', $values, $this->_getEntityTypeId('catalog_product'), 0);
 
-        $attribute = $resource->getAttribute('media_gallery', $this->_entity_type_id('catalog_product'));
+        $attribute = $resource->getAttribute('media_gallery', $this->_getEntityTypeId('catalog_product'));
 
         if (!$attribute) {
             $task->setMessage($helper->__('Attribute %s not found', 'media_gallery'));

--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -442,7 +442,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                 $this->getTable(),
                 array(
                     'entity_id'        => 'entity_id',
-                    'entity_type_id'   => $this->_zde($this->_entity_type_id('catalog_product')),
+                    'entity_type_id'   => $this->_zde($this->_getEntityTypeId('catalog_product')),
                     'attribute_set_id' => $family,
                     'type_id'          => '_type_id',
                     'sku'              => 'code',
@@ -487,7 +487,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
             $values['visibility'] = $this->_zde('IF(`_type_id` = "simple" AND `groups` <> "", 1, 4)');
         }
 
-        $this->getRequest()->setValues($this->getCode(), 'catalog/product', $values, $this->_entity_type_id('catalog_product'), 0);
+        $this->getRequest()->setValues($this->getCode(), 'catalog/product', $values, $this->_getEntityTypeId('catalog_product'), 0);
 
         /* @var $helper Pimgento_Core_Helper_Data */
         $helper = Mage::helper('pimgento_core');
@@ -551,7 +551,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                             }
 
                             $this->getRequest()->setValues(
-                                $this->getCode(), 'catalog/product', $values, $this->_entity_type_id('catalog_product'), $storeId
+                                $this->getCode(), 'catalog/product', $values, $this->_getEntityTypeId('catalog_product'), $storeId
                             );
                         }
 
@@ -857,14 +857,14 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
         $priceId = $adapter->fetchOne(
             $adapter->select()
                 ->from($resource->getTable('eav/attribute'), array('attribute_id'))
-                ->where('entity_type_id = ?', $this->_entity_type_id('catalog_product'))
+                ->where('entity_type_id = ?', $this->_getEntityTypeId('catalog_product'))
                 ->where('attribute_code = ?', 'price')
                 ->limit(1));
 
         $specialPriceId = $adapter->fetchOne(
             $adapter->select()
                 ->from($resource->getTable('eav/attribute'), array('attribute_id'))
-                ->where('entity_type_id = ?', $this->_entity_type_id('catalog_product'))
+                ->where('entity_type_id = ?', $this->_getEntityTypeId('catalog_product'))
                 ->where('attribute_code = ?', 'special_price')
                 ->limit(1));
 

--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -487,7 +487,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
             $values['visibility'] = $this->_zde('IF(`_type_id` = "simple" AND `groups` <> "", 1, 4)');
         }
 
-        $this->getRequest()->setValues($this->getCode(), 'catalog/product', $values, 4, 0);
+        $this->getRequest()->setValues($this->getCode(), 'catalog/product', $values, $this->_entity_type_id('catalog_product'), 0);
 
         /* @var $helper Pimgento_Core_Helper_Data */
         $helper = Mage::helper('pimgento_core');
@@ -551,7 +551,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                             }
 
                             $this->getRequest()->setValues(
-                                $this->getCode(), 'catalog/product', $values, 4, $storeId
+                                $this->getCode(), 'catalog/product', $values, $this->_entity_type_id('catalog_product'), $storeId
                             );
                         }
 

--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -576,7 +576,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                 }
 
                 $this->getRequest()->setValues(
-                    $this->getCode(), 'catalog/product', $values, 4, 0
+                    $this->getCode(), 'catalog/product', $values, $this->_getEntityTypeId('catalog_product'), 0
                 );
             }
 
@@ -824,7 +824,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
 
                 if (count($values)) {
                     $this->getRequest()->setValues(
-                        $this->getCode(), 'catalog/product', $values, 4, $data['id']
+                        $this->getCode(), 'catalog/product', $values, $this->_getEntityTypeId('catalog_product'), $data['id']
                     );
                 }
 

--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -442,7 +442,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                 $this->getTable(),
                 array(
                     'entity_id'        => 'entity_id',
-                    'entity_type_id'   => $this->_zde(4),
+                    'entity_type_id'   => $this->_zde($this->_entity_type_id('catalog_product')),
                     'attribute_set_id' => $family,
                     'type_id'          => '_type_id',
                     'sku'              => 'code',
@@ -857,14 +857,14 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
         $priceId = $adapter->fetchOne(
             $adapter->select()
                 ->from($resource->getTable('eav/attribute'), array('attribute_id'))
-                ->where('entity_type_id = ?', 4)
+                ->where('entity_type_id = ?', $this->_entity_type_id('catalog_product'))
                 ->where('attribute_code = ?', 'price')
                 ->limit(1));
 
         $specialPriceId = $adapter->fetchOne(
             $adapter->select()
                 ->from($resource->getTable('eav/attribute'), array('attribute_id'))
-                ->where('entity_type_id = ?', 4)
+                ->where('entity_type_id = ?', $this->_entity_type_id('catalog_product'))
                 ->where('attribute_code = ?', 'special_price')
                 ->limit(1));
 


### PR DESCRIPTION
The entity_type_id (for at least products) appears to be hard-carded.  Instead it should be looked up as the ID could (and in my case is) different then the one you have hard-coded to.

Use 

    select entity_type_id from eav_entity_type where entity_type_code='catalog_product';

to find the correct entity_type_id for products. Use "catalog_category" as the entity_type_code when looking for the ID for categories.