### PR TITLE
Import empty fields as NULL

### DIFF
--- a/app/code/community/Pimgento/Core/Model/Resource/Request.php
+++ b/app/code/community/Pimgento/Core/Model/Resource/Request.php
@@ -191,20 +191,30 @@ class Pimgento_Core_Model_Resource_Request extends Mage_Core_Model_Resource_Db_A
 
                 if ($attribute['backend_type'] !== 'static') {
 
-                    $select = $adapter->select()
-                        ->from(
-                            $this->getTableName($name),
-                            array(
-                                'entity_type_id' => new Zend_Db_Expr($entityTypeId),
-                                'attribute_id'   => new Zend_Db_Expr($attribute['attribute_id']),
-                                'store_id'       => new Zend_Db_Expr($storeId),
-                                'entity_id'      => 'entity_id',
-                                'value'          => $value
-                            )
-                        );
-
-                    if ($this->columnExists($this->getTableName($name), $value)) {
-                        $select->where('TRIM(`' . $value . '`) <> ?', new Zend_Db_Expr('""'));
+                    if($value instanceof Zend_Db_Expr){
+                        $select = $adapter->select()
+                            ->from(
+                                $this->getTableName($name),
+                                array(
+                                    'entity_type_id' => new Zend_Db_Expr($entityTypeId),
+                                    'attribute_id'   => new Zend_Db_Expr($attribute['attribute_id']),
+                                    'store_id'       => new Zend_Db_Expr($storeId),
+                                    'entity_id'      => 'entity_id',
+                                    'value'          => $value,
+                                )
+                            );
+                    } else {
+                        $select = $adapter->select()
+                            ->from(
+                                $this->getTableName($name),
+                                array(
+                                    'entity_type_id' => new Zend_Db_Expr($entityTypeId),
+                                    'attribute_id'   => new Zend_Db_Expr($attribute['attribute_id']),
+                                    'store_id'       => new Zend_Db_Expr($storeId),
+                                    'entity_id'      => 'entity_id',
+                                    'value'          => new Zend_Db_Expr('IF(`' . $this->getTableName($name) . '`.`' . $value . '` <> "",`' . $this->getTableName($name) . '`.`' . $value . '`,NULL)'),
+                                )
+                            );
                     }
 
                     $backendType = $attribute['backend_type'];


### PR DESCRIPTION
On v1.0.3 empty fields were imported to numeric database fields as 0 (conversion from empty string).
The latest version even just ignored empty fields, making it unable to empty an previously set field.

This patch is mostly useful for numeric fields to show that they're not used like a price.

I stumbled across this due to a mapping a row to special_price and all empty fields got imported as 0 and thus making the special price 0.00 active.

In our case the special setPrices method of the product importer didn't got used since we haven't the price fields in other stores/currencies/countries.
(And we have a few more price fields which wouldn't handled by the setPrices method anyway.) 