### PR TITLE
Fill status if not imported

### DIFF
--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -987,6 +987,63 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
 
         $adapter->query($insert);
 
+        $isActiveAttribute = $resource->getAttribute('is_active', 3);
+        $statusAttribute = $resource->getAttribute('status', 4);
+
+        // Products without a status: set it to enabled if at least one category is active
+        $select = $adapter->select()
+            ->from(
+                ['cp' => $resource->getTable('catalog/category_product')],
+                [
+                    'entity_type_id' => $this->_zde(4),
+                    'attribute_id' => $this->_zde($statusAttribute['attribute_id']),
+                    'store_id' => $this->_zde(0),
+                    'entity_id' => 'product_id',
+                    'value' => $this->_zde(Mage_Catalog_Model_Product_Status::STATUS_ENABLED),
+                ]
+            )->joinInner(
+                ['a' => $resource->getValueTable('catalog/category', $isActiveAttribute['backend_type'])],
+                '`cp`.`category_id` = `a`.`entity_id`',
+                []
+            )->where(
+                '`a`.`attribute_id` = ?', $isActiveAttribute['attribute_id']
+            )->where(
+                '`a`.`value` = ?', 1
+            )->group(
+                'product_id'
+            );
+
+        $insert = $adapter->insertFromSelect(
+            $select,
+            $resource->getValueTable('catalog/product', $statusAttribute['backend_type']),
+            ['entity_type_id', 'attribute_id', 'store_id', 'entity_id', 'value'],
+            Varien_Db_Adapter_Pdo_Mysql::INSERT_IGNORE
+        );
+
+        $adapter->query($insert);
+
+        // Products without a status: set it to disabled
+        $select = $adapter->select()
+            ->from(
+                $resource->getTable('catalog/product'),
+                [
+                    'entity_type_id' => $this->_zde(4),
+                    'attribute_id' => $this->_zde($statusAttribute['attribute_id']),
+                    'store_id' => $this->_zde(0),
+                    'entity_id' => 'entity_id',
+                    'value' => $this->_zde(Mage_Catalog_Model_Product_Status::STATUS_DISABLED),
+                ]
+            );
+
+        $insert = $adapter->insertFromSelect(
+            $select,
+            $resource->getValueTable('catalog/product', $statusAttribute['backend_type']),
+            ['entity_type_id', 'attribute_id', 'store_id', 'entity_id', 'value'],
+            Varien_Db_Adapter_Pdo_Mysql::INSERT_IGNORE
+        );
+
+        $adapter->query($insert);
+
         return true;
     }
 


### PR DESCRIPTION
For products without a status:
Set it to enabled if it's in at least one active category otherwise disable it.

This does not conflict with products which already have a status.
Is useful if the import should not overwrite the current status.