### PR TITLE
Replace quotes from csv header when getting the first line info

### DIFF
--- a/app/code/community/Pimgento/Core/Model/Request.php
+++ b/app/code/community/Pimgento/Core/Model/Request.php
@@ -180,7 +180,7 @@ class Pimgento_Core_Model_Request extends Mage_Core_Model_Abstract
     public function getFirstLine($file)
     {
         $handle = fopen($file, 'r');
-        $line = preg_replace("/\\r|\\n/", "", fgets($handle));
+        $line = preg_replace("/\\r|\\n|\"|'/", "", fgets($handle));
         fclose($handle);
 
         $fieldsTerminated = Mage::getStoreConfig('pimdata/general/csv_fields_terminated');


### PR DESCRIPTION
If the header fields are enclosed between quotes the import does not work. When getting the firstLine of the file, these quotes are not replaced and the field name does not match with columnExists at the time of setting the values. Replacing the quotes in the method getFirstLine fixes this issue.