### PR TITLE
Fix to ensure that FPC is cleared

### DIFF
--- a/app/code/community/Pimgento/Core/Model/Import/Abstract.php
+++ b/app/code/community/Pimgento/Core/Model/Import/Abstract.php
@@ -47,7 +47,10 @@ abstract class Pimgento_Core_Model_Import_Abstract
         $tags = $this->getConfig('cache');
         if ($tags) {
             Mage::app()->cleanCache(explode(',', $tags));
-
+            if (strpos($tags, 'full_page')) {
+                Enterprise_PageCache_Model_Cache::getCacheInstance()->clean(Enterprise_PageCache_Model_Processor::CACHE_TAG);
+                Mage::app()->getCacheInstance()->cleanType('full_page');
+            }
             $task->setMessage(
                 Mage::helper('pimgento_core')->__('Cache cleaned for: %s', $tags)
             );


### PR DESCRIPTION
Full page cache is not cleared after the import even when this is set into the PIMGento configuration. Extra lines to ensure that the FPC is cleared have been added.