### PR TITLE
Fixed option import when the attribute is exclded

### DIFF
--- a/app/code/community/Pimgento/Option/Model/Import.php
+++ b/app/code/community/Pimgento/Option/Model/Import.php
@@ -14,6 +14,27 @@ class Pimgento_Option_Model_Import extends Pimgento_Core_Model_Import_Abstract
     protected $_code = 'option';
 
     /**
+     * Remove exclusion from config
+     *
+     * @return bool
+     */
+    public function deleteExclusion()
+    {
+        parent::deleteExclusion();
+
+        $exclusions = Mage::getStoreConfig('pimdata/attribute/exclusions');
+
+        if ($exclusions) {
+            $exclusions = explode(',', $exclusions);
+            foreach ($exclusions as $code) {
+                $this->getAdapter()->delete($this->getTable(), array('attribute = ?' => $code));
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Create table (Step 1)
      *
      * @param Pimgento_Core_Model_Task $task

--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -393,7 +393,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                         array(
                             'c' => $resource->getTable('pimgento_core/code')
                         ),
-                        'FIND_IN_SET(REPLACE(`c`.`code`,"' . $columnPrefix . '_",""), `p`.`' . $column . '`)
+                        'FIND_IN_SET(INSERT(`c`.`code`, LOCATE("' . $columnPrefix . '_", `c`.`code`), LENGTH("' . $columnPrefix . '_"), ""), `p`.`' . $column . '`)
                         AND `c`.`import` = "' . $option->getCode() . '"',
                         array(
                             $column => new Zend_Db_Expr('GROUP_CONCAT(`c`.`entity_id` SEPARATOR ",")')


### PR DESCRIPTION
When we exclude attributes from the import, related options aren't automatically excluded and thus creates an SQL error (when using innoDB).

This PR fixes the issue by excluding options related to excluded attributes