### PR TITLE
Fixed product option import when the attribute option code contains attr code

### DIFF
--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -393,7 +393,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                         array(
                             'c' => $resource->getTable('pimgento_core/code')
                         ),
-                        'FIND_IN_SET(REPLACE(`c`.`code`,"' . $columnPrefix . '_",""), `p`.`' . $column . '`)
+                        'FIND_IN_SET(INSERT(`c`.`code`, LOCATE("' . $columnPrefix . '_", `c`.`code`), LENGTH("' . $columnPrefix . '_"), ""), `p`.`' . $column . '`)
                         AND `c`.`import` = "' . $option->getCode() . '"',
                         array(
                             $column => new Zend_Db_Expr('GROUP_CONCAT(`c`.`entity_id` SEPARATOR ",")')


### PR DESCRIPTION
When one uses, in Akeneo, the attribute's code as a prefix for attributes options codes, the values doesn't match while importing data in Magento.

This change fixes the issue