### PR TITLE
Support mapping of product attribute names with '-'

### DIFF
--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -527,9 +527,9 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
 
                 if (preg_match('/^(.*)-(.*)$/', $column)) {
 
-                    $translation = true;
-
                     if (preg_match('/^(?P<attribute>[^-]*)-' . $code . '$/', $column, $matches)) {
+
+                        $translation = true;
 
                         foreach ($ids as $key => $storeId) {
 
@@ -587,11 +587,11 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                     foreach ($match as $attribute) {
                         $values[$attribute] = $column;
                     }
-                }
 
-                $this->getRequest()->setValues(
-                    $this->getCode(), 'catalog/product', $values, 4, 0
-                );
+                    $this->getRequest()->setValues(
+                        $this->getCode(), 'catalog/product', $values, 4, 0
+                    );
+                }
             }
 
         }


### PR DESCRIPTION
Akeneo v1.5 product export automatically adds the metric field value, e.g. weight and weight-unit.  The current code does not support mapping of weight-unit to a legal Magento attribute, e.g. weight_unit through the configuration page.  This modification supports this mapping.