### PR TITLE
Write Magento Image labels based on a tidied up image filename

### DIFF
--- a/app/code/community/Pimgento/Image/Model/Import.php
+++ b/app/code/community/Pimgento/Image/Model/Import.php
@@ -162,8 +162,15 @@ class Pimgento_Image_Model_Import extends Pimgento_Core_Model_Import_Abstract
                     $data[$type] = $picture['name'];
                 }
 
-                $gallery[] = $picture['name'];
-
+                if (Mage::getStoreConfig('pimdata/image/set_labels')) {
+                    // Get Label text from filename without extension and with some tidying
+                    $_filename = basename($picture['file']);
+                    $withoutExt = preg_replace('/\\.[^.\\s]{3,4}$/', '', $_filename);
+                    $label = preg_replace('/_/', ' ', $withoutExt);
+                    $gallery[] = ucwords($label) . '||' . $picture['name'];
+                } else {
+                    $gallery[] = $picture['name'];
+                }
                 $key++;
             }
 
@@ -227,18 +234,26 @@ class Pimgento_Image_Model_Import extends Pimgento_Core_Model_Import_Abstract
 
         while (($row = $query->fetch())) {
 
-            $images = explode(',', $row['gallery']);
+            $imageData = explode(',', $row['gallery']);
 
             $table = $resource->getTable('catalog/product_attribute_media_gallery');
 
             $adapter->delete($table, 'entity_id = ' . $row['entity_id']);
 
-            foreach ($images as $key => $image) {
+            foreach ($imageData as $key => $imageItem) {
 
+                if (Mage::getStoreConfig('pimdata/image/set_labels')) {
+                    $imageInfo = explode('||', $imageItem);
+                    $imageFile = $imageInfo[1];
+                    $imageLabel = $imageInfo[0];
+                } else {
+                    $imageFile = $imageItem;
+                    $imageLabel = null;
+                }
                 $values = array(
                     'attribute_id' => $attributeId,
                     'entity_id'    => $row['entity_id'],
-                    'value'        => $image
+                    'value'        => $imageFile
                 );
 
                 $adapter->insertOnDuplicate($table, $values, array('value'));
@@ -252,7 +267,7 @@ class Pimgento_Image_Model_Import extends Pimgento_Core_Model_Import_Abstract
                             ->from($table, array('value_id'))
                             ->where('attribute_id = ?', $attributeId)
                             ->where('entity_id = ?', $row['entity_id'])
-                            ->where('value = ?', $image)
+                            ->where('value = ?', $imageFile)
                             ->limit(1)
                     );
                 }
@@ -261,7 +276,7 @@ class Pimgento_Image_Model_Import extends Pimgento_Core_Model_Import_Abstract
                     $values = array(
                         'value_id' => $valueId,
                         'store_id' => 0,
-                        'label'    => null,
+                        'label'    => $imageLabel,
                         'position' => $key,
                         'disabled' => 0
                     );
@@ -277,6 +292,7 @@ class Pimgento_Image_Model_Import extends Pimgento_Core_Model_Import_Abstract
 
         return true;
     }
+
 
     /**
      * Drop table (Step 6)

--- a/app/code/community/Pimgento/Image/etc/config.xml
+++ b/app/code/community/Pimgento/Image/etc/config.xml
@@ -40,6 +40,7 @@
                 <cron_enabled>0</cron_enabled>
                 <delete>1</delete>
                 <cache>1</cache>
+                <set_labels>1</set_labels>
             </image>
         </pimdata>
     </default>

--- a/app/code/community/Pimgento/Image/etc/system.xml
+++ b/app/code/community/Pimgento/Image/etc/system.xml
@@ -62,10 +62,10 @@
                             <show_in_store>0</show_in_store>
                         </cache>
                         <set_labels translate="label">
-                            <label>Add Image Labels from Filenames</label>
+                            <label>Set Image Labels from Filenames</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <comment>Add labels using tidied up filename (capitalised, without extension, underscore => space)</comment>
+                            <comment>Set labels using the image filename (capitalised, extension removed and underscore replaced by spaces)</comment>
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>

--- a/app/code/community/Pimgento/Image/etc/system.xml
+++ b/app/code/community/Pimgento/Image/etc/system.xml
@@ -61,6 +61,16 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </cache>
+                        <set_labels translate="label">
+                            <label>Add Image Labels from Filenames</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <comment>Add labels using tidied up filename (capitalised, without extension, underscore => space)</comment>
+                            <sort_order>5</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </set_labels>
                     </fields>
                 </image>
             </groups>

--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -527,9 +527,9 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
 
                 if (preg_match('/^(.*)-(.*)$/', $column)) {
 
-                    if (preg_match('/^(?P<attribute>[^-]*)-' . $code . '$/', $column, $matches)) {
+                    $translation = true;
 
-                        $translation = true;
+                    if (preg_match('/^(?P<attribute>[^-]*)-' . $code . '$/', $column, $matches)) {
 
                         foreach ($ids as $key => $storeId) {
 
@@ -587,11 +587,11 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                     foreach ($match as $attribute) {
                         $values[$attribute] = $column;
                     }
-
-                    $this->getRequest()->setValues(
-                        $this->getCode(), 'catalog/product', $values, 4, 0
-                    );
                 }
+
+                $this->getRequest()->setValues(
+                    $this->getCode(), 'catalog/product', $values, 4, 0
+                );
             }
 
         }


### PR DESCRIPTION
I wanted to set my image labels to the product name and/or item colour.  As my image filenames could be used for this purpose I wrote a change the image importer to set the label to the filename with certain edits, i.e. capitalised, underscores removed etc.

In doing this I also notice that filenames with ',' were being lost due to the gallery being encoded using commas.  I've changed the encoding arbitrarily to '%%'.  Likewise, I arbitrarily encode the filename/label using '||.

Not sure if this functionality is wanted/needed in PIMGento but I thought I'd offer it up.

Martin