### PR TITLE
Fixes #175: Fixed Flash uploader drop in Magento 1.9.3

### DIFF
--- a/app/code/community/Pimgento/Core/Block/Adminhtml/Launcher.php
+++ b/app/code/community/Pimgento/Core/Block/Adminhtml/Launcher.php
@@ -5,7 +5,7 @@
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Pimgento_Core_Block_Adminhtml_Launcher extends Mage_Adminhtml_Block_Media_Uploader
+class Pimgento_Core_Block_Adminhtml_Launcher extends Mage_Uploader_Block_Multiple
 {
 
     /**
@@ -17,7 +17,7 @@ class Pimgento_Core_Block_Adminhtml_Launcher extends Mage_Adminhtml_Block_Media_
 
         $this->setTemplate('pimgento/launcher.phtml');
 
-        $params = $this->getConfig()->getParams();
+        $params = $this->getUploaderConfig()->getParams();
 
         $type = $this->_getMediaType();
 
@@ -37,10 +37,11 @@ class Pimgento_Core_Block_Adminhtml_Launcher extends Mage_Adminhtml_Block_Media_
         /* @var $urlModel Mage_Adminhtml_Model_Url */
         $urlModel = Mage::getModel('adminhtml/url');
 
-        $this->getConfig()
-             ->setUrl($urlModel->addSessionParam()->getUrl('adminhtml/task/upload', array('type' => $type)))
+        $this->getUploaderConfig()
+             ->setSingleFile(true)
+             ->setTarget($urlModel->addSessionParam()->getUrl('adminhtml/task/upload', array('type' => $type)))
              ->setParams($params)
-             ->setFileField('file')
+             ->setFileParameterName('file')
              ->setFilters(array(
                     'files' => array(
                         'label' => $helper->__('File (%s)', implode(', ', $labels)),
@@ -80,14 +81,19 @@ class Pimgento_Core_Block_Adminhtml_Launcher extends Mage_Adminhtml_Block_Media_
         return $this->getRequest()->getParam('type');
     }
 
+    public function getExecuteButtonHtml()
+    {
+        return $this->getChildHtml('execute_button');
+    }
+
     /**
      * Get html code of button
      *
      * @return string
      */
-    public function getExecuteButtonHtml()
+    public function getUploadButtonHtml()
     {
-        return $this->getChildHtml('execute_button');
+        return $this->getChild('upload_button')->toHtml();
     }
 
     /**

--- a/app/code/community/Pimgento/Core/controllers/Adminhtml/TaskController.php
+++ b/app/code/community/Pimgento/Core/controllers/Adminhtml/TaskController.php
@@ -9,6 +9,16 @@ class Pimgento_Core_Adminhtml_TaskController extends Mage_Adminhtml_Controller_A
 {
 
     /**
+     * Check the permission to run it
+     *
+     * @return boolean
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('catalog/pimgento_data');
+    }
+
+    /**
      * Index Action
      */
     public function indexAction()

--- a/app/design/adminhtml/default/default/layout/pimgento.xml
+++ b/app/design/adminhtml/default/default/layout/pimgento.xml
@@ -11,9 +11,10 @@
         <reference name="head">
             <action method="addCss"><name>pimgento/css/style.css</name></action>
             <action method="addItem"><type>skin_js</type><name>pimgento/js/script.js</name></action>
-            <action method="addJs"><script>lib/flex.js</script></action>
-            <action method="addJs"><script>lib/FABridge.js</script></action>
-            <action method="addJs"><script>mage/adminhtml/flexuploader.js</script></action>
+            <action method="addJs"><name>lib/uploader/flow.min.js</name></action>
+            <action method="addJs"><name>lib/uploader/fusty-flow.js</name></action>
+            <action method="addJs"><name>lib/uploader/fusty-flow-factory.js</name></action>
+            <action method="addJs"><name>mage/adminhtml/uploader/instance.js</name></action>
         </reference>
         <reference name="content">
             <block type="pimgento_core/adminhtml_task" name="pimgento.core.task" template="pimgento/task.phtml" />

--- a/app/design/adminhtml/default/default/template/pimgento/launcher.phtml
+++ b/app/design/adminhtml/default/default/template/pimgento/launcher.phtml
@@ -29,23 +29,22 @@
         <div id="type-file" class="task-execute" style="display:none">
             <div id="<?php echo $this->getHtmlId() ?>" class="uploader">
                 <div class="buttons">
-                    <div id="<?php echo $this->getHtmlId() ?>-install-flash" style="display:none">
-                        <?php echo $this->__('This content requires last version of Adobe Flash Player.') ?>
-                    </div>
+                    <?php echo $this->getBrowseButtonHtml(); ?>
+                    <?php echo $this->getUploadButtonHtml(); ?>
                 </div>
-                <div class="clear"></div>
-                <div class="no-display" id="<?php echo $this->getHtmlId() ?>-template">
-                    <div id="{{id}}" class="file-row">
-                    <span class="file-info">{{name}} ({{size}})</span>
+            </div>
+            <div class="no-display" id="<?php echo $this->getElementId('template') ?>">
+                <div id="{{id}}-container" class="file-row">
+                    <span class="file-info">{{name}} {{size}}</span>
                     <span class="delete-button"><?php echo $this->getDeleteButtonHtml() ?></span>
                     <span class="progress-text"></span>
                     <div class="clear"></div>
-                    </div>
-                </div>
-                <div class="no-display" id="<?php echo $this->getHtmlId() ?>-template-progress">
-                    {{percent}}% {{uploaded}} / {{total}}
                 </div>
             </div>
+            <div class="no-display" id="<?php echo $this->getHtmlId() ?>-template-progress">
+                {{percent}}% {{uploaded}} / {{total}}
+            </div>
+            <?php echo $this->getChildHtml('additional_scripts'); ?>
         </div>
         <div id="type-button" class="task-execute" style="display:none">
             <?php echo $this->getExecuteButtonHtml() ?>
@@ -56,35 +55,32 @@
 
 <script type="text/javascript">
 //<![CDATA[
-    maxUploadFileSizeInBytes = <?php echo $this->getDataMaxSizeInBytes() ?>;
-    maxUploadFileSize = '<?php echo $this->getDataMaxSize() ?>';
-
     function initUploader() {
 
         $$('#type-file .complete').each(function(item) {
             item.remove();
         });
 
-        <?php echo $this->getJsObjectName() ?> = new Flex.Uploader('<?php echo $this->getHtmlId() ?>', '<?php echo $this->getSkinUrl('media/uploader.swf') ?>', <?php echo $this->getConfigJson() ?>);
-        <?php echo $this->getJsObjectName() ?>.onFilesComplete = function(completedFiles) {
-            completedFiles.each(function(file){
-                var id = <?php echo $this->getJsObjectName() ?>.getFileId(file);
+        var uploader = new Uploader(<?php echo $this->getJsonConfig(); ?>);
 
-                var progress = $(id).down('.progress-text');
+        if (varienGlobalEvents) {
+            varienGlobalEvents.attachEventHandler('tabChangeBefore', uploader.onContainerHideBefore);
+        }
 
-                progress.update('<?php echo $this->getExecuteButtonHtml() ?>');
-                progress.down().rel = file.response.replace(/"/g, "");
+        uploader._handleDelete = function() {}; // We do not want to remove uploaded file container after upload.
 
-                var lastId = $$('.file-row').last().id;
-                if (lastId !== id) {
-                    $(id).down('.progress-text').update(Translator.translate('Complete'));
-                }
+        document.on('uploader:fileSuccess', function(event) {
+            var id = event.memo.containerId;
+
+            $$('#tasks-types .file-row.complete').each(function(elem) {
+                elem.down('.progress-text').update(Translator.translate('Complete'));
             });
-        };
 
-        var flash = $('<?php echo $this->getHtmlId() ?>-flash');
-        if (flash != undefined) { flash.setStyle({float:'none'}); }
+            var progress = $(id).down('.progress-text');
 
+            progress.update($('type-button').innerHTML);
+            progress.down().rel = event.memo.response.replace(/"/g, "");
+        });
     }
 
     $('task-command').observe('change', function() {


### PR DESCRIPTION
This PR uses new uploader (no more Flash plugin) as it has been removed from Magento 1.9.3 (or patch SUPEE-8788).

**It is not backward compatible with previous Magento versions.**

Known issue: consecutive uploads/imports for the same task are not correctly handled.
