### PR TITLE
Fixed performance problem on removing products from categories

### DIFF
--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -1119,8 +1119,16 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                 array()
             );
 
-        $adapter->delete($resource->getTable('catalog/category_product'),
-            '(category_id, product_id) IN (' . $selectToDelete->assemble() . ')');
+        $delete = '            
+            DELETE ccp.* FROM ' . $resource->getTable('catalog/category_product') . ' ccp           
+             JOIN (' . $select->__toString() . ') e ON e.product_id = ccp.product_id            
+             WHERE NOT EXISTS  (                
+                 SELECT * FROM (' . $select->__toString() . ') f                
+                 WHERE f.product_id = ccp.product_id
+                 AND f.category_id = ccp.category_id
+             )
+             ';
+        $adapter->query($delete);
 
         return true;
     }


### PR DESCRIPTION
With several hundreds of categories, the part to remove products from categories can take several minutes, even for an really small import (only 1 product)...

(At least on Magento EE 1.14)

This solution was provided by @AurelienLavorel. Many thanks to him!
