### PR TITLE
Added feature to delete CSV file at the end of cron import task

### DIFF
--- a/app/code/community/Pimgento/Core/Model/Observer.php
+++ b/app/code/community/Pimgento/Core/Model/Observer.php
@@ -1,0 +1,18 @@
+<?php
+
+class Pimgento_Core_Model_Observer
+{
+    public function removeImportedFiles(Varien_Event_Observer $observer)
+    {
+        if (!Mage::getStoreConfig('pimdata/general/remove_csv_file_after_cron_import')) {
+            return;
+        }
+
+        /* @var $task Pimgento_Core_Model_Task */
+        $task = $observer->getEvent()->getTask();
+
+        $file = $task->getFile();
+
+        unlink($file);
+    }
+}

--- a/app/code/community/Pimgento/Core/Model/Observer.php
+++ b/app/code/community/Pimgento/Core/Model/Observer.php
@@ -13,6 +13,7 @@ class Pimgento_Core_Model_Observer
 
         $file = $task->getFile();
 
-        unlink($file);
+        if (file_exists($file))
+            unlink($file);
     }
 }

--- a/app/code/community/Pimgento/Core/etc/config.xml
+++ b/app/code/community/Pimgento/Core/etc/config.xml
@@ -81,6 +81,14 @@
                     </pimgento_core_log_task_error>
                 </observers>
             </task_executor_error>
+            <task_executor_cron_end>
+                <observers>
+                    <sauvel_accessories_add_accessories_to_cart>
+                        <class>pimgento_core/observer</class>
+                        <method>removeImportedFiles</method>
+                    </sauvel_accessories_add_accessories_to_cart>
+                </observers>
+            </task_executor_cron_end>
         </events>
     </global>
     <admin>
@@ -122,6 +130,7 @@
                 <csv_fields_enclosure>"</csv_fields_enclosure>
                 <admin_lang>en_US</admin_lang>
                 <csv_load_data_infile>1</csv_load_data_infile>
+                <remove_csv_file_after_cron_import>0</remove_csv_file_after_cron_import>
             </general>
         </pimdata>
     </default>

--- a/app/code/community/Pimgento/Core/etc/system.xml
+++ b/app/code/community/Pimgento/Core/etc/system.xml
@@ -89,6 +89,15 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </websites>
+                        <remove_csv_file_after_cron_import translate="label">
+                            <label>Cron: delete CSV file after import</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </remove_csv_file_after_cron_import>
                     </fields>
                 </general>
             </groups>

--- a/app/locale/en_US/Pimgento_Core.csv
+++ b/app/locale/en_US/Pimgento_Core.csv
@@ -149,3 +149,4 @@
 "CSV: Use MySql Load Data File","CSV: Use MySql Load Data File"
 "Asset import is not available","Asset import is not available"
 "Please select asset attribute in Pimgento Configuration (Asset)","Please select asset attribute in Pimgento Configuration (Asset)"
+"Cron: delete CSV file after import","Cron: delete CSV file after import"

--- a/app/locale/fr_FR/Pimgento_Core.csv
+++ b/app/locale/fr_FR/Pimgento_Core.csv
@@ -150,3 +150,4 @@
 "Asset import is not available","L'import des assets n'est pas disponible"
 "Please select asset attribute in Pimgento Configuration (Asset)","Merci de sélectionner l'attribut asset dans la configuration de Pimgento (Asset)"
 "Use variant import for axis","Utiliser l'import des variant pour les axes"
+"Cron: delete CSV file after import","Cron : supprimer le fichier CSV après import"


### PR DESCRIPTION
When importing PIM data from CSV files in cron tasks, the CSV file is not removed from filesystem.
So import will be launched next time. Which is useless.
This feature allows to delete CSV file when data has been imported, at the end of cron task.