### PR TITLE
use attributes from family import for mapping

### DIFF
--- a/app/code/community/Pimgento/Attribute/Model/Import.php
+++ b/app/code/community/Pimgento/Attribute/Model/Import.php
@@ -324,11 +324,11 @@ class Pimgento_Attribute_Model_Import extends Pimgento_Core_Model_Import_Abstrac
                 ->where('attribute_code = ?', $model->getAttributeCode());
             $query = $adapter->query($sql);
 
-            if ($query->fetchAll()) {
+            if ($row = $query->fetch()) {
                 $families = array();
-                while($row = $query->fetch()) {
+                do {
                     array_push($families, $row['family_code']);
-                }
+                } while ($row = $query->fetch());
             } else {
                 $defaultAttributeSets = Mage::getStoreConfig('pimdata/attribute/families');
                 $data['families'] = $defaultAttributeSets;

--- a/app/code/community/Pimgento/Family/Model/Import.php
+++ b/app/code/community/Pimgento/Family/Model/Import.php
@@ -120,7 +120,43 @@ class Pimgento_Family_Model_Import extends Pimgento_Core_Model_Import_Abstract
     }
 
     /**
-     * Init default Group (Step 5)
+     * Insert family attribute relations (Step 5)
+     *
+     * @param Pimgento_Core_Model_Task $task
+     *
+     * @return bool
+     */
+    public function insertFamilyAttributeRelations($task) {
+        $resource = $this->getResource();
+        $adapter = $this->getAdapter();
+
+        $values = $adapter
+            ->select()
+            ->from(
+                $this->getTable(),
+                array(
+                    'family_code' => 'code',
+                    'attribute_code' => 'attributes'
+                )
+            );
+
+        $query = $adapter->query($values);
+
+        while ($row = $query->fetch()) {
+            $attributes = explode(',', $row['attribute_code']);
+            foreach ($attributes as $attribute) {
+                $adapter->insert(
+                    'pimgento_family_attribute_relations',
+                    array('family_code' => $row['family_code'], 'attribute_code' => $attribute)
+                );
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Init default Group (Step 6)
      *
      * @param Pimgento_Core_Model_Task $task
      *
@@ -171,7 +207,7 @@ class Pimgento_Family_Model_Import extends Pimgento_Core_Model_Import_Abstract
     }
 
     /**
-     * Drop table (Step 6)
+     * Drop table (Step 7)
      *
      * @param Pimgento_Core_Model_Task $task
      *

--- a/app/code/community/Pimgento/Family/Model/Import.php
+++ b/app/code/community/Pimgento/Family/Model/Import.php
@@ -129,9 +129,11 @@ class Pimgento_Family_Model_Import extends Pimgento_Core_Model_Import_Abstract
     public function insertFamilyAttributeRelations($task) {
         $resource = $this->getResource();
         $adapter = $this->getAdapter();
+        $familyAttributeRelationsTable = 'pimgento_family_attribute_relations';
 
-        $values = $adapter
-            ->select()
+        $adapter->delete($familyAttributeRelationsTable);
+
+        $values = $adapter->select()
             ->from(
                 $this->getTable(),
                 array(
@@ -146,7 +148,7 @@ class Pimgento_Family_Model_Import extends Pimgento_Core_Model_Import_Abstract
             $attributes = explode(',', $row['attribute_code']);
             foreach ($attributes as $attribute) {
                 $adapter->insert(
-                    'pimgento_family_attribute_relations',
+                    $familyAttributeRelationsTable,
                     array('family_code' => $row['family_code'], 'attribute_code' => $attribute)
                 );
             }

--- a/app/code/community/Pimgento/Family/Model/Observer.php
+++ b/app/code/community/Pimgento/Family/Model/Observer.php
@@ -47,14 +47,18 @@ class Pimgento_Family_Model_Observer
                         'method'  => 'pimgento_family/import::insertFamily'
                     ),
                     5 => array(
+                        'comment' => $helper->__('Create family attribute relations'),
+                        'method'  => 'pimgento_family/import::insertFamilyAttributeRelations'
+                    ),
+                    6 => array(
                         'comment' => $helper->__('Init default groups'),
                         'method'  => 'pimgento_family/import::initDefaultGroup'
                     ),
-                    6 => array(
+                    7 => array(
                         'comment' => $helper->__('Drop temporary table'),
                         'method'  => 'pimgento_family/import::dropTable'
                     ),
-                    7 => array(
+                    8 => array(
                         'comment' => $helper->__('Clean cache'),
                         'method'  => 'pimgento_family/import::cleanCache'
                     ),

--- a/app/code/community/Pimgento/Family/etc/config.xml
+++ b/app/code/community/Pimgento/Family/etc/config.xml
@@ -18,6 +18,17 @@
                 <class>Pimgento_Family_Model</class>
             </pimgento_family>
         </models>
+        <resources>
+            <pimgento_family_setup>
+                <setup>
+                    <module>Pimgento_Family</module>
+                    <class>Mage_Core_Model_Resource_Setup</class>
+                </setup>
+                <connection>
+                    <use>core_setup</use>
+                </connection>
+            </pimgento_family_setup>
+        </resources>
         <helpers>
             <pimgento_family>
                 <class>Pimgento_Family_Helper</class>

--- a/app/code/community/Pimgento/Family/sql/pimgento_family_setup/mysql4-install-1.0.0.php
+++ b/app/code/community/Pimgento/Family/sql/pimgento_family_setup/mysql4-install-1.0.0.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author    Agence Dn'D <magento@dnd.fr>
+ * @copyright Copyright (c) 2015 Agence Dn'D (http://www.dnd.fr)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/* @var $installer Mage_Core_Model_Resource_Setup */
+$installer = $this;
+
+$installer->startSetup();
+
+$installer->run("
+
+DROP TABLE IF EXISTS `{$this->getTable('pimgento_family_attribute_relations')}`;
+CREATE TABLE `{$this->getTable('pimgento_family_attribute_relations')}` (
+    `id`                INT(11) unsigned NOT NULL AUTO_INCREMENT,
+    `family_code`       VARCHAR(255) NOT NULL,
+    `attribute_code`    VARCHAR(255) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Pimgento family attribute relations';
+
+");
+
+$installer->endSetup();


### PR DESCRIPTION
To be able to use the native "akeneo_csv_export" of the "Akeneo CSV Connector" instead of using the "EnhancedConnectorBundle" it is necessary to link the family to the attributes during the family import. While importing the attributes the link is used to add the attributes to the correct attribute set.