### PR TITLE
Fix asset sort order while importing product

### DIFF
--- a/app/code/community/Pimgento/Product/Model/Import.php
+++ b/app/code/community/Pimgento/Product/Model/Import.php
@@ -1357,7 +1357,7 @@ class Pimgento_Product_Model_Import extends Pimgento_Core_Model_Import_Abstract
                     array('a' => Mage::getSingleton('core/resource')->getTableName('pimgento_asset')),
                     'FIND_IN_SET(`a`.`asset`, `p`.`' . $attributeCode . '`)',
                     array(
-                        'image' => $this->_zde('GROUP_CONCAT(DISTINCT `a`.`image` SEPARATOR "|")'),
+                        'image' => $this->_zde('GROUP_CONCAT(DISTINCT `a`.`image` ORDER BY `a`.`asset` SEPARATOR "|")'),
                     )
                 )
                 ->joinInner(


### PR DESCRIPTION
Ajout d'un ORDER BY dans la requête de récupération des images produits.
Cela permet de fix l'ordre des assets ensuite renseignés dans la media gallery : sans le ORDER BY, l'ordre était défini par rapport aux valeurs de la colonne 'image'.